### PR TITLE
fixing input kind on video capture device.

### DIFF
--- a/packages/sources/src/VideoCapture.ts
+++ b/packages/sources/src/VideoCapture.ts
@@ -13,7 +13,7 @@ export class VideoCaptureSource<
   constructor(args: CustomInputArgs<VideoCaptureSourceSettings, Filters>) {
     super({
       ...args,
-      kind: "av_capture_input",
+      kind: "dshow_input",
     });
   }
 }


### PR DESCRIPTION
obs updated source kind for video capture devices from av_input to dshow_input